### PR TITLE
Simplify prepareArgs

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -138,7 +138,7 @@ Context.prototype.onEvent = function (event) {
 
 //additional agi commands
 
-commands.map(function (command) { 
+commands.forEach(function (command) { 
   var str = '';
   Context.prototype[command.name] = function () {
     if (command.params > 0) {
@@ -152,28 +152,16 @@ commands.map(function (command) {
 });
 
 var prepareArgs = function (args, argsRules, count) {
-  var q, argsP = [];
-  if (argsRules && count) {
-
-    args = args.map(function (arg){
-      return arg.toString();
-    });
-
-    for (var i = 0; i < count; i++) {
-      argsP[i] = (args[i]) ?
-                  args[i] : 
-                  ((argsRules[i] && argsRules[i].default) ? 
-                    argsRules[i].default :
-                    '');
-    }
-
-    q = argsP.map(function (arg, i) {
-      return (argsRules[i] && argsRules[i].prepare) ? argsRules[i].prepare(arg) : arg;
-    });
-  } else {
-    q = args;
+  if (!argsRules || !count) {
+    return args;
   }
-  return q;
+
+  return Array.apply(null, new Array(count)) // old node.js versions don't support Array.fill()
+    .map(function (arg, i) {
+      arg = args[i] !== undefined && args[i] !== null ? args[i] : argsRules[i] && argsRules[i].default || '';
+      var prepare = argsRules[i] && argsRules[i].prepare || function (x) { return x; };
+      return prepare(String(arg));
+    });
 };
 
 //sugar commands


### PR DESCRIPTION
The logic stays the same with one minor exception:
numeric arguments are now also acceptable (1.toString() -> error, but String(1) = '1').
