### PR TITLE
Allow binding AGI server to specified host

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,8 @@ var agi = function (handler, optionsIn) {
 
   var settings = {
     port: options.port || 3000,
-    debug: options.debug || false
+    debug: options.debug || false,
+    host: options.host,
   };
 
   var handle = function (stream) {
@@ -15,9 +16,10 @@ var agi = function (handler, optionsIn) {
     handler(context);
   };
 
-  var start = function (portIn) {
+  var start = function (portIn, hostIn) {
     var port = portIn || settings.port;
-    return require('net').createServer(handle).listen(port);
+    var host = hostIn || settings.host;
+    return require('net').createServer(handle).listen(port, host);
   }; 
 
   return {


### PR DESCRIPTION
In some environments AGI should listen only on single interface (for reverse proxy or limited access from local network). 